### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -23,7 +23,7 @@ jobs:
         WITH_V: true
 
     - name: Build and publish Docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: musawirali/abzen/${{ steps.tagger-step.outputs.new_tag }}
         username: musawirali


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore